### PR TITLE
bugfix: make variable `word` completely defined

### DIFF
--- a/src/pdm/installers/synchronizers.py
+++ b/src/pdm/installers/synchronizers.py
@@ -479,6 +479,7 @@ class Synchronizer(BaseSynchronizer):
                     word = "a"
                 else:
                     covering["synchronize"][17] = True
+                    word = "an editable"
 
                 live.console.print(f"Installing the project as {word} package...")
                 if self_key in self.working_set: #17


### PR DESCRIPTION
change so that `word` gets assigned in both branches

closes #25 