### PR TITLE
Fix bug due to faulty refactoring in _merge_bounds_and_excludes

### DIFF
--- a/src/pdm/models/specifiers.py
+++ b/src/pdm/models/specifiers.py
@@ -140,107 +140,80 @@ class PySpecSet(SpecifierSet):
         from tests import covering
         sorted_excludes = sorted(excludes)
 
-        # Changed code to work with branch coverage tool
-        #wildcard_excludes = set()
         wildcard_excludes = {version[:-1] for version in sorted_excludes if version.is_wildcard}
-        # for version in sorted_excludes:
-        #     covering["_merge_bounds_and_excludes"][0] = True
-        #     if version.is_wildcard:
-        #         covering["_merge_bounds_and_excludes"][1] = True
-        #         wildcard_excludes.add(version[:-1])
-        #     else:
-        #         covering["_merge_bounds_and_excludes"][2] = True         
-
-        # Changed code to work with branch coverage tool
-        #sorted_excludes = []
         sorted_excludes = [
             version
             for version in sorted_excludes
             if version.is_wildcard or not any(version.startswith(wv) for wv in wildcard_excludes)
-        ]
-        # for version in sorted_excludes:
-        #     covering["_merge_bounds_and_excludes"][3] = True
-        #     starts_with_wv = False
-        #     for wv in wildcard_excludes:
-        #         covering["_merge_bounds_and_excludes"][4] = True
-        #         if version.startswith(wv):
-        #             covering["_merge_bounds_and_excludes"][5] = True
-        #             starts_with_wv = True 
-        #         else:
-        #             covering["_merge_bounds_and_excludes"][6] = True
-        #     if version.is_wildcard or starts_with_wv:
-        #         covering["_merge_bounds_and_excludes"][7] = True
-        #         sorted_excludes.append(version)
-        #     else:
-        #         covering["_merge_bounds_and_excludes"][8] = True         
+        ]       
 
         if lower == Version.MIN and upper == Version.MAX:
-            covering["_merge_bounds_and_excludes"][9] = True
+            covering["_merge_bounds_and_excludes"][0] = True
             # Nothing we can do here, it is a non-constraint.
             return lower, upper, sorted_excludes
         else:
-            covering["_merge_bounds_and_excludes"][10] = True
+            covering["_merge_bounds_and_excludes"][1] = True
 
 
         for version in list(sorted_excludes):  # from to low to high
-            covering["_merge_bounds_and_excludes"][11] = True
+            covering["_merge_bounds_and_excludes"][2] = True
             if version >= upper:
-                covering["_merge_bounds_and_excludes"][12] = True
+                covering["_merge_bounds_and_excludes"][3] = True
                 sorted_excludes[:] = []
                 break
             else:
-                covering["_merge_bounds_and_excludes"][13] = True
+                covering["_merge_bounds_and_excludes"][4] = True
 
             if version.is_wildcard:
-                covering["_merge_bounds_and_excludes"][14] = True
+                covering["_merge_bounds_and_excludes"][5] = True
                 valid_length = len(version._version) - 1
                 valid_version = version[:valid_length]
 
                 if valid_version < lower[:valid_length]:
-                    covering["_merge_bounds_and_excludes"][15] = True
+                    covering["_merge_bounds_and_excludes"][6] = True
                     # Useless excludes
                     sorted_excludes.remove(version)
                 elif lower.startswith(valid_version):
-                    covering["_merge_bounds_and_excludes"][16] = True
+                    covering["_merge_bounds_and_excludes"][7] = True
                     # The lower bound is excluded, e.g: >=3.7.3,!=3.7.*
                     # bump the lower version in the last common bit: >=3.8.0
                     lower = version.bump(-2)
                     sorted_excludes.remove(version)
                 else:
-                    covering["_merge_bounds_and_excludes"][17] = True
+                    covering["_merge_bounds_and_excludes"][8] = True
                     break
             else:
-                covering["_merge_bounds_and_excludes"][18] = True
+                covering["_merge_bounds_and_excludes"][9] = True
                 if version < lower:
-                    covering["_merge_bounds_and_excludes"][19] = True
+                    covering["_merge_bounds_and_excludes"][10] = True
                     sorted_excludes.remove(version)
                 elif version == lower:
-                    covering["_merge_bounds_and_excludes"][20] = True
+                    covering["_merge_bounds_and_excludes"][11] = True
                     lower = version.bump()
                     sorted_excludes.remove(version)
                 else:
-                    covering["_merge_bounds_and_excludes"][21] = True
+                    covering["_merge_bounds_and_excludes"][12] = True
                     break
         for version in reversed(sorted_excludes):  # from high to low
-            covering["_merge_bounds_and_excludes"][22] = True
+            covering["_merge_bounds_and_excludes"][13] = True
 
             if version >= upper:
-                covering["_merge_bounds_and_excludes"][23] = True
+                covering["_merge_bounds_and_excludes"][14] = True
                 sorted_excludes.remove(version)
                 continue
             else:
-                covering["_merge_bounds_and_excludes"][24] = True
+                covering["_merge_bounds_and_excludes"][15] = True
 
             if not version.is_wildcard:
-                covering["_merge_bounds_and_excludes"][25] = True
+                covering["_merge_bounds_and_excludes"][16] = True
                 break
             else:
-                covering["_merge_bounds_and_excludes"][26] = True
+                covering["_merge_bounds_and_excludes"][17] = True
             valid_length = len(version._version) - 1
             valid_version = version[:valid_length]
 
             if upper.startswith(valid_version) or version.bump(-2) == upper:
-                covering["_merge_bounds_and_excludes"][27] = True
+                covering["_merge_bounds_and_excludes"][18] = True
                 # Case 1: The upper bound is excluded, e.g: <3.7.3,!=3.7.*
                 # set the upper to the zero version: <3.7.0
                 # Case 2: The upper bound is adjacent to the excluded one,
@@ -249,7 +222,7 @@ class PySpecSet(SpecifierSet):
                 upper = valid_version.complete()
                 sorted_excludes.remove(version)
             else:
-                covering["_merge_bounds_and_excludes"][28] = True
+                covering["_merge_bounds_and_excludes"][19] = True
                 break
 
         return lower, upper, sorted_excludes

--- a/src/pdm/models/specifiers.py
+++ b/src/pdm/models/specifiers.py
@@ -141,32 +141,38 @@ class PySpecSet(SpecifierSet):
         sorted_excludes = sorted(excludes)
 
         # Changed code to work with branch coverage tool
-        wildcard_excludes = set()
-        for version in sorted_excludes:
-            covering["_merge_bounds_and_excludes"][0] = True
-            if version.is_wildcard:
-                covering["_merge_bounds_and_excludes"][1] = True
-                wildcard_excludes.add(version[:-1])
-            else:
-                covering["_merge_bounds_and_excludes"][2] = True         
+        #wildcard_excludes = set()
+        wildcard_excludes = {version[:-1] for version in sorted_excludes if version.is_wildcard}
+        # for version in sorted_excludes:
+        #     covering["_merge_bounds_and_excludes"][0] = True
+        #     if version.is_wildcard:
+        #         covering["_merge_bounds_and_excludes"][1] = True
+        #         wildcard_excludes.add(version[:-1])
+        #     else:
+        #         covering["_merge_bounds_and_excludes"][2] = True         
 
         # Changed code to work with branch coverage tool
-        sorted_excludes = []
-        for version in sorted_excludes:
-            covering["_merge_bounds_and_excludes"][3] = True
-            starts_with_wv = False
-            for wv in wildcard_excludes:
-                covering["_merge_bounds_and_excludes"][4] = True
-                if version.startswith(wv):
-                    covering["_merge_bounds_and_excludes"][5] = True
-                    starts_with_wv = True 
-                else:
-                    covering["_merge_bounds_and_excludes"][6] = True
-            if version.is_wildcard or starts_with_wv:
-                covering["_merge_bounds_and_excludes"][7] = True
-                sorted_excludes.append(version)
-            else:
-                covering["_merge_bounds_and_excludes"][8] = True         
+        #sorted_excludes = []
+        sorted_excludes = [
+            version
+            for version in sorted_excludes
+            if version.is_wildcard or not any(version.startswith(wv) for wv in wildcard_excludes)
+        ]
+        # for version in sorted_excludes:
+        #     covering["_merge_bounds_and_excludes"][3] = True
+        #     starts_with_wv = False
+        #     for wv in wildcard_excludes:
+        #         covering["_merge_bounds_and_excludes"][4] = True
+        #         if version.startswith(wv):
+        #             covering["_merge_bounds_and_excludes"][5] = True
+        #             starts_with_wv = True 
+        #         else:
+        #             covering["_merge_bounds_and_excludes"][6] = True
+        #     if version.is_wildcard or starts_with_wv:
+        #         covering["_merge_bounds_and_excludes"][7] = True
+        #         sorted_excludes.append(version)
+        #     else:
+        #         covering["_merge_bounds_and_excludes"][8] = True         
 
         if lower == Version.MIN and upper == Version.MAX:
             covering["_merge_bounds_and_excludes"][9] = True

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,7 +8,7 @@ covering = {}
 # example: The function 'export' has 24 branches 
 covering["export"] = [False for _ in range(24)]
 covering["synchronize"] = [False for _ in range(20)]
-covering["_merge_bounds_and_excludes"] = [False for _ in range(29)]
+covering["_merge_bounds_and_excludes"] = [False for _ in range(20)]
 covering["do_update"] = [False for _ in range(47)]
 
 # This is called at the end, and pretty-prints the branch coverage 


### PR DESCRIPTION
The bug was due to an incorrect refactoring of two list comprehensions.
To resolve the bug, I brought back the old version. Doing this, our
ad-hoc branch coverage tool won't catch the branches in the list
comprehensions but so be it.

Resolves #40 